### PR TITLE
Fix POD errors

### DIFF
--- a/scripts/parse.pl
+++ b/scripts/parse.pl
@@ -88,8 +88,6 @@ canonocal_date() is called on each element in the result from parser), on separa
 
 Default: 0.
 
-=back
-
 Try these:
 
 	perl scripts/parse.pl -max debug -d 'From 21 Jun 1950 to @#dGerman@ 05.Dez.2015'
@@ -137,5 +135,7 @@ See the Log::handler docs.
 Default: 'error'.
 
 No lower levels are used.
+
+=back
 
 =cut

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,7 @@
+use strict;
+use Test::More;
+eval "use Test::Pod 1.00";
+plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
+my @poddirs = qw( blib scripts );
+all_pod_files_ok( all_pod_files( @poddirs ) );
+


### PR DESCRIPTION
Moved a misplaced '=back' directive, that was closing an item list to
soon.

Also added a test of all POD.

This is part of the CPAN Pull Request Challenge, where I got
Genealogy::Gedcom::Date as my May assignment.